### PR TITLE
add events based on player advancements

### DIFF
--- a/src/main/java/io/github/fabriccommunity/events/impl/AdvancementsImpl.java
+++ b/src/main/java/io/github/fabriccommunity/events/impl/AdvancementsImpl.java
@@ -1,0 +1,45 @@
+package io.github.fabriccommunity.events.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.github.fabriccommunity.events.play.PlayerAdvancementEvents;
+
+import net.minecraft.entity.EntityType;
+import net.minecraft.item.Item;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+public class AdvancementsImpl {
+	private static final Map<Item, Event<PlayerAdvancementEvents.ItemDurabilityChanged>> ITEM_DURAB_EVENTS = new HashMap<>();
+	private static final Map<EntityType<?>, Event<PlayerAdvancementEvents.PlayerHurtEntity>> HURT_ENTITY_EVENTS = new HashMap<>();
+	private static final Map<EntityType<?>, Event<PlayerAdvancementEvents.PlayerKilledEntity>> KILL_ENTITY_EVENTS = new HashMap<>();
+
+	public static Event<PlayerAdvancementEvents.ItemDurabilityChanged> itemDurabEvent(Item item) {
+		return ITEM_DURAB_EVENTS.computeIfAbsent(item, i -> EventFactory.createArrayBacked(PlayerAdvancementEvents.ItemDurabilityChanged.class,
+				listeners -> (player, stack, damage) -> {
+			for (PlayerAdvancementEvents.ItemDurabilityChanged event : listeners) {
+				event.onItemDurabilityChange(player, stack, damage);
+			}
+		}));
+	}
+
+	public static Event<PlayerAdvancementEvents.PlayerHurtEntity> hurtEntityEvent(EntityType<?> type) {
+		return HURT_ENTITY_EVENTS.computeIfAbsent(type, t -> EventFactory.createArrayBacked(PlayerAdvancementEvents.PlayerHurtEntity.class,
+				listeners -> (attacker, victim, source, dealt, taken, blocked) -> {
+			for (PlayerAdvancementEvents.PlayerHurtEntity event : listeners) {
+				event.onPlayerHurtEntity(attacker, victim, source, dealt, taken, blocked);
+			}
+		}));
+	}
+
+	public static Event<PlayerAdvancementEvents.PlayerKilledEntity> killedEntityEvent(EntityType<?> type) {
+		return KILL_ENTITY_EVENTS.computeIfAbsent(type, t -> EventFactory.createArrayBacked(PlayerAdvancementEvents.PlayerKilledEntity.class,
+				listeners -> (killer, victim, source) -> {
+					for (PlayerAdvancementEvents.PlayerKilledEntity event : listeners) {
+						event.onPlayerKillEntity(killer, victim, source);
+					}
+				}));
+	}
+}

--- a/src/main/java/io/github/fabriccommunity/events/mixin/advancement/MixinInventoryChangedCriterion.java
+++ b/src/main/java/io/github/fabriccommunity/events/mixin/advancement/MixinInventoryChangedCriterion.java
@@ -1,0 +1,20 @@
+package io.github.fabriccommunity.events.mixin.advancement;
+
+import io.github.fabriccommunity.events.play.PlayerAdvancementEvents;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.advancement.criterion.InventoryChangedCriterion;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+@Mixin(InventoryChangedCriterion.class)
+public class MixinInventoryChangedCriterion {
+	@Inject(method = "trigger(Lnet/minecraft/server/network/ServerPlayerEntity;Lnet/minecraft/entity/player/PlayerInventory;Lnet/minecraft/item/ItemStack;III)V", at = @At("HEAD"))
+	private void injectEvent(ServerPlayerEntity player, PlayerInventory inventory, ItemStack stack, int full, int empty, int occupied, CallbackInfo info) {
+		PlayerAdvancementEvents.INVENTORY_CHANGED.invoker().onInventoryChange(player, inventory, stack, full, empty, occupied);
+	}
+}

--- a/src/main/java/io/github/fabriccommunity/events/mixin/advancement/MixinItemDurabilityChangedCriterion.java
+++ b/src/main/java/io/github/fabriccommunity/events/mixin/advancement/MixinItemDurabilityChangedCriterion.java
@@ -1,0 +1,20 @@
+package io.github.fabriccommunity.events.mixin.advancement;
+
+import io.github.fabriccommunity.events.play.PlayerAdvancementEvents;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.advancement.criterion.ItemDurabilityChangedCriterion;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+@Mixin(ItemDurabilityChangedCriterion.class)
+public class MixinItemDurabilityChangedCriterion {
+	@Inject(method = "trigger", at = @At("HEAD"))
+	private void injectEvent(ServerPlayerEntity player, ItemStack stack, int damage, CallbackInfo info) {
+		PlayerAdvancementEvents.ITEM_DURABILITY_CHANGED_WILDCARD.invoker().onItemDurabilityChange(player, stack, damage);
+		PlayerAdvancementEvents.itemDurabilityChanged(stack.getItem()).invoker().onItemDurabilityChange(player, stack, damage);
+	}
+}

--- a/src/main/java/io/github/fabriccommunity/events/mixin/advancement/MixinOnKilledCriterion.java
+++ b/src/main/java/io/github/fabriccommunity/events/mixin/advancement/MixinOnKilledCriterion.java
@@ -1,0 +1,26 @@
+package io.github.fabriccommunity.events.mixin.advancement;
+
+import io.github.fabriccommunity.events.play.PlayerAdvancementEvents;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.advancement.criterion.Criteria;
+import net.minecraft.advancement.criterion.OnKilledCriterion;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+@Mixin(OnKilledCriterion.class)
+public class MixinOnKilledCriterion {
+	@Inject(method = "trigger", at = @At("HEAD"))
+	private void injectEvent(ServerPlayerEntity player, Entity entity, DamageSource source, CallbackInfo info) {
+		if ((Object)this == Criteria.ENTITY_KILLED_PLAYER) {
+			PlayerAdvancementEvents.ENTITY_KILLED_PLAYER.invoker().onEntityKillPlayer(player, entity, source);
+		} else if ((Object)this == Criteria.PLAYER_KILLED_ENTITY) {
+			PlayerAdvancementEvents.PLAYER_KILLED_ENTITY_WILDCARD.invoker().onPlayerKillEntity(player, entity, source);
+			PlayerAdvancementEvents.playerKilledEntity(entity.getType()).invoker().onPlayerKillEntity(player, entity, source);
+		}
+	}
+}

--- a/src/main/java/io/github/fabriccommunity/events/mixin/advancement/MixinPlayerHurtEntityCriterion.java
+++ b/src/main/java/io/github/fabriccommunity/events/mixin/advancement/MixinPlayerHurtEntityCriterion.java
@@ -1,0 +1,21 @@
+package io.github.fabriccommunity.events.mixin.advancement;
+
+import io.github.fabriccommunity.events.play.PlayerAdvancementEvents;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.advancement.criterion.PlayerHurtEntityCriterion;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+@Mixin(PlayerHurtEntityCriterion.class)
+public class MixinPlayerHurtEntityCriterion {
+	@Inject(method = "trigger", at = @At("HEAD"))
+	private void injectEvent(ServerPlayerEntity player, Entity entity, DamageSource source, float dealt, float taken, boolean blocked, CallbackInfo info) {
+		PlayerAdvancementEvents.PLAYER_HURT_ENTITY_WILDCARD.invoker().onPlayerHurtEntity(player, entity, source, dealt, taken, blocked);
+		PlayerAdvancementEvents.playerHurtEntity(entity.getType()).invoker().onPlayerHurtEntity(player, entity, source, dealt, taken, blocked);
+	}
+}

--- a/src/main/java/io/github/fabriccommunity/events/mixin/player/MixinPlayerEntity.java
+++ b/src/main/java/io/github/fabriccommunity/events/mixin/player/MixinPlayerEntity.java
@@ -31,7 +31,7 @@ public class MixinPlayerEntity {
 		}
 	}
 
-	@Inject(at = @At("HEAD"), method = "wakeUp")
+	@Inject(at = @At("HEAD"), method = "wakeUp(ZZ)V")
 	private void wakeUp(boolean bl, boolean updateSleepingPlayers, CallbackInfo info) {
 		PlayerInteractionEvents.WAKE_UP.invoker().onWakeUp((PlayerEntity) (Object) this, updateSleepingPlayers, bl);
 	}

--- a/src/main/java/io/github/fabriccommunity/events/play/PlayerAdvancementEvents.java
+++ b/src/main/java/io/github/fabriccommunity/events/play/PlayerAdvancementEvents.java
@@ -1,0 +1,164 @@
+package io.github.fabriccommunity.events.play;
+
+import io.github.fabriccommunity.events.impl.AdvancementsImpl;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+public class PlayerAdvancementEvents {
+
+	/**
+	 * An event run when a player is killed by an entity.
+	 */
+	public static final Event<EntityKilledPlayer> ENTITY_KILLED_PLAYER = EventFactory.createArrayBacked(EntityKilledPlayer.class, listeners -> (victim, killer, source) -> {
+		for (EntityKilledPlayer listener : listeners) {
+			listener.onEntityKillPlayer(victim, killer, source);
+		}
+	});
+
+	/**
+	 * An event run when a player's inventory is changed.
+	 */
+	public static final Event<InventoryChanged> INVENTORY_CHANGED = EventFactory.createArrayBacked(InventoryChanged.class, listeners -> (player, inventory, stack, full, empty, occupied) -> {
+		for (InventoryChanged listener : listeners) {
+			listener.onInventoryChange(player, inventory, stack, full, empty, occupied);
+		}
+	});
+
+	/**
+	 * An event run when the durability of a stack of *any* item is changed.
+	 */
+	public static final Event<ItemDurabilityChanged> ITEM_DURABILITY_CHANGED_WILDCARD = EventFactory.createArrayBacked(ItemDurabilityChanged.class,
+			listeners -> (player, stack, damage) -> {
+		for (ItemDurabilityChanged listener : listeners) {
+			listener.onItemDurabilityChange(player, stack, damage);
+		}
+	});
+
+	/**
+	 * An event run when the durability of a stack of <item> is changed.
+	 * @param item The item to listen for.
+	 * @return The event for that type of item.
+	 */
+	public static Event<ItemDurabilityChanged> itemDurabilityChanged(Item item) {
+		return AdvancementsImpl.itemDurabEvent(item);
+	}
+
+	/**
+	 * An event run when a player hurts *any* type of entity.
+	 */
+	public static final Event<PlayerHurtEntity> PLAYER_HURT_ENTITY_WILDCARD = EventFactory.createArrayBacked(PlayerHurtEntity.class,
+			listeners -> (attacker, victim, source, dealt, taken, blocked) -> {
+		for (PlayerHurtEntity listener : listeners) {
+			listener.onPlayerHurtEntity(attacker, victim, source, dealt, taken, blocked);
+		}
+	});
+
+	/**
+	 * An event run when a player hurts a specific type of entity.
+	 * @param type The type of entity to listen for.
+	 * @return The event for that entity type.
+	 */
+	public static Event<PlayerHurtEntity> playerHurtEntity(EntityType<?> type) {
+		return AdvancementsImpl.hurtEntityEvent(type);
+	}
+
+	/**
+	 * An event run when a player kills *any* type of entity.
+	 */
+	public static final Event<PlayerKilledEntity> PLAYER_KILLED_ENTITY_WILDCARD = EventFactory.createArrayBacked(PlayerKilledEntity.class,
+			listeners -> (killer, victim, source) -> {
+		for (PlayerKilledEntity listener : listeners) {
+			listener.onPlayerKillEntity(killer, victim, source);
+		}
+	});
+
+	/**
+	 * An event run when a play kills a specific type of entity.
+	 * @param type The type of entity to listen for.
+	 * @return The event for that entity type.
+	 */
+	public static Event<PlayerKilledEntity> playerKilledEntity(EntityType<?> type) {
+		return AdvancementsImpl.killedEntityEvent(type);
+	}
+
+	/**
+	 * An event run when a player is killed by an entity.
+	 * @author b0undary
+	 */
+	public interface EntityKilledPlayer {
+		/**
+		 * @param victim The player killed.
+		 * @param killer The entity who killed the player.
+		 * @param source The damage source used to kill.
+		 */
+		void onEntityKillPlayer(PlayerEntity victim, Entity killer, DamageSource source);
+	}
+
+	/**
+	 * An event run when a player's inventory is changed.
+	 * @author b0undary
+	 */
+	public interface InventoryChanged {
+		/**
+		 * @param player The player whose inventory changed.
+		 * @param inventory The inventory changed.
+		 * @param stack The stack that got changed.
+		 * @param full How many full item stacks are in the inventory.
+		 * @param empty How many empty item stacks are in the inventory.
+		 * @param occupied How many slots are occupied in the inventory.
+		 */
+		void onInventoryChange(ServerPlayerEntity player, PlayerInventory inventory, ItemStack stack, int full, int empty, int occupied);
+	}
+
+	/**
+	 * An event run when the durability of an item stack is changed.
+	 * @author b0undary
+	 */
+	public interface ItemDurabilityChanged {
+		/**
+		 * @param player The player whose item durability changed.
+		 * @param stack The stack that got changed.
+		 * @param damage How much total damage the stack has now.
+		 */
+		void onItemDurabilityChange(ServerPlayerEntity player, ItemStack stack, int damage);
+	}
+
+	/**
+	 * An event run when a player hurts an entity.
+	 * @author b0undary
+	 */
+	public interface PlayerHurtEntity {
+		/**
+		 * @param attacker The player doing the hurting.
+		 * @param victim The entity that got hurt.
+		 * @param source The damage source used.
+		 * @param dealt How much damage was dealt.
+		 * @param taken How much damage was actually taken.
+		 * @param blocked Whether the attack got blocked.
+		 */
+		void onPlayerHurtEntity(ServerPlayerEntity attacker, Entity victim, DamageSource source, float dealt, float taken, boolean blocked);
+	}
+
+	/**
+	 * An event run when a play kills an entity.
+	 * @author b0undary
+	 */
+	public interface PlayerKilledEntity {
+		/**
+		 * @param killer The player doing the killing.
+		 * @param victim The entity that got killed.
+		 * @param source The damage source used to kill.
+		 */
+		void onPlayerKillEntity(ServerPlayerEntity killer, Entity victim, DamageSource source);
+	}
+}

--- a/src/main/java/io/github/fabriccommunity/events/play/PlayerInteractionEvents.java
+++ b/src/main/java/io/github/fabriccommunity/events/play/PlayerInteractionEvents.java
@@ -138,7 +138,7 @@ public final class PlayerInteractionEvents {
 		/**
 		 * @param hungerManager the hunger manager.
 		 * @param original the original food level that was going to be added to the hunger manager.
-		 * @param food the food level to be added to the hunger manager. If the value contained in this does not equal {@code original}, the value has been modded.
+		 * @param hunger the food level to be added to the hunger manager. If the value contained in this does not equal {@code original}, the value has been modded.
 		 * @return
 		 * <ul>
 		 * <li>{@code SUCCESS} or {@code CONSUME} to cancel further event processing and add the food level in {@code hunger}.<br/>
@@ -178,7 +178,7 @@ public final class PlayerInteractionEvents {
 		/**
 		 * @param player the player waking up.
 		 * @param updateSleepingPlayers whether to run {@link ServerWorld#updateSleepingPlayers} if server side.
-		 * @param whether to set the sleep timer to 0 instead of 100.
+		 * @param setSleepTimerTo0 whether to set the sleep timer to 0 instead of 100.
 		 */
 		void onWakeUp(PlayerEntity player, boolean updateSleepingPlayers, boolean setSleepTimerTo0);
 	}

--- a/src/main/resources/toomanyevents.mixins.json
+++ b/src/main/resources/toomanyevents.mixins.json
@@ -4,6 +4,10 @@
   "package": "io.github.fabriccommunity.events.mixin",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
+    "advancement.MixinInventoryChangedCriterion",
+    "advancement.MixinItemDurabilityChangedCriterion",
+    "advancement.MixinOnKilledCriterion",
+    "advancement.MixinPlayerHurtEntityCriterion",
     "biomegen.MixinMultiNoiseBiomeSource",
     "biomegen.MixinTheEndBiomeSource",
     "biomegen.MixinVanillaLayeredBiomeSource",


### PR DESCRIPTION
Pulled over from my former project [Common Callbacks](http://github.com/cottonmc/commoncallbacks) which never got off the ground. Adds five new events based on advancement criteria:

- an event fired when a player is killed by an entity.
- an event fired when a player's inventory updates.
- an event fired when an item stack's durability updates.
- an event fired when a player hurts an entity.
- an event fired when a player kills an entity.

All of these events are fired after-the-fact, so they're not cancellable.